### PR TITLE
Correctly validate the project prompt input.

### DIFF
--- a/lib/commands/project.js
+++ b/lib/commands/project.js
@@ -539,6 +539,8 @@ project.chooseProjectPrompt = function(projects, projectName, cb) {
       name : 'project',
       description : 'Project Number?',
       warning : 'Project number has to be between 1 and ' + projects.length,
+      required : true,
+      type : 'number',
       minimum : 1,
       maximum : projects.length
     }], function(err, result) {


### PR DESCRIPTION
It was possible to enter alpha characters, numbers out of range of the
project list, or nothing when prompted to select a project. The prompt input
will now correctly validate that input was added, and that it is a number within
range of the available projects.

Related to issue #9.
