### PR TITLE
Bump demeteorizer dependency to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "progress": "0.1.x",
     "underscore": "1.4.x",
     "fstream-ignore": "0.0.x",
-    "demeteorizer": "0.3.x",
+    "demeteorizer": "0.6.x",
     "fs-tools": "~0.2.10",
     "find-file-sync": "0.0.2",
     "update-notifier": "~0.1.7"


### PR DESCRIPTION
Looks like the Modulus CLI is using an older version of demeteorizer which will bundle Meteor projects and use an older version of Node (0.10.22) when current version of Meteor need Node 0.10.25+

Not sure if there is a reason the modulus CLI isn't using the newer versions of demeteorizer. This pull request bumps it to the latest version.
