### PR TITLE
-s command line option for log streaming

### DIFF
--- a/lib/commands/project.js
+++ b/lib/commands/project.js
@@ -452,10 +452,11 @@ project.clearLogs = function(projectName, cb) {
 
 /** Description - Streams logs for a specific project
  * @param {string} projectName - name of the project to retrieve logs from.
+ * @param [string] servoNumber - 1 based index of the servo to stream logs from
  * @param {function} cb - Callback invoked with stream data
 **/
 //--------------------------------------------------------------------
-project.streamLogs = function(projectName, cb){
+project.streamLogs = function(projectName, servoNumber, cb){
   projectController.find({
       userId : userConfig.data.userId
     },
@@ -498,9 +499,12 @@ project.streamLogs = function(projectName, cb){
           return go();
         }
 
-        project.chooseServoPrompt(selectedProject, null, function(err, servo) {
+        project.chooseServoPrompt(selectedProject, servoNumber, function(err, servo) {
           if(err) {
-            return cb(err);
+            err = error.handleApiError(err, 'GET_PROJECT_LOGS', cb);
+            if(err.length > 0) {
+              return cb(err);
+            }
           }
 
           selectedServo = servo;
@@ -629,11 +633,11 @@ project._createProjectPrompt = function(cb) {
 /**
  * Displays a prompt for choosing a servo.
  * @param {Object} project The project object.
- * @param {String} [servoId] Default selection.
+ * @param {String} [servoNumber] Default selection.
  * @param {Function} cb
  */
 //-----------------------------------------------------------------------------
-project.chooseServoPrompt = function(project, servoId, cb) {
+project.chooseServoPrompt = function(project, servoNumber, cb) {
 
   if(project.pus.length === 0) {
     return cb(null, null);
@@ -641,6 +645,15 @@ project.chooseServoPrompt = function(project, servoId, cb) {
 
   if(project.pus.length === 1) {
     return cb(null, project.pus[0])
+  }
+
+  // A default servo selection has been made. Find matching servo instance
+  if(typeof servoNumber === 'string') {
+    if(project.pus[servoNumber -1]) {
+      return cb(null, project.pus[servoNumber - 1]);
+    } else {
+      return cb({ code: 'NO_MATCHING_SERVO_NUM' });
+    }
   }
 
   modulus.io.print('Please choose which servo to use:'.input);

--- a/lib/common/error.js
+++ b/lib/common/error.js
@@ -142,6 +142,11 @@ error.responseCodes = {
     level: 1,
     message: 'No project found that matches specified name.'
   },
+  NO_MATCHING_SERVO_NUM: {
+    id : 'NO_MATCHING_SERVO_NUM',
+    level: 1,
+    message: 'No matching servo number found in project.'
+  },
   NO_MATCHING_DB_NAME: {
     id : 'NO_MATCHING_DB_NAME',
     level: 1,

--- a/lib/routes/project.js
+++ b/lib/routes/project.js
@@ -133,6 +133,7 @@ module.exports = function(modulus) {
 
   modulus.program
     .option('-p, --project-name [value]', 'Name of the project to retrieve logs from. Prompts are skipped when specified')
+    .option('-s, --servo-number [value]', 'Number of the servo to retrieve logs from. Prompts are skipped when specified')
     .option('-d, --download', 'Flag that signals to download the logs instead of printing them.')
     .option('-o, --output [value]', 'Specifies the file to download to. Must be file type tar.gz')
     .option('-m, --include-modules', 'Flag that indicates whether or not to include the node_modules folder in the bundle.')
@@ -165,6 +166,7 @@ module.exports = function(modulus) {
     this.line('Gets logs for the selected project.'.input);
     this.line('  options:'.input);
     this.line('    -p, --project-name   Name of the project to retrieve logs from. Prompts are skipped when specified.'.input);
+    this.line('    -s, --servo-number    Number of the servo to stream logs from. Prompts are skipped when specified.'.input);
     this.line('    -d, --download       Flag that signals to download the logs instead of printing them.'.input);
     this.line('    -o, --output         Specifies the file to download to. Must be file type tar.gz'.input);
     this.line('');
@@ -229,7 +231,7 @@ module.exports = function(modulus) {
     .description('Streams logs for the selected project.')
     .on('--help', help.commands.logStream)
     .action(function(dir){
-      modulus.runCommand(modulus.commands.project.streamLogs, [modulus.program.projectName], true);
+      modulus.runCommand(modulus.commands.project.streamLogs, [modulus.program.projectName, modulus.program.servoNumber], true);
     });
 
   // project logs tail -> logs tail alias
@@ -238,7 +240,7 @@ module.exports = function(modulus) {
     .description('Streams logs for the selected project.')
     .on('--help', help.commands.logStream)
     .action(function(dir){
-      modulus.runCommand(modulus.commands.project.streamLogs, [modulus.program.projectName], true);
+      modulus.runCommand(modulus.commands.project.streamLogs, [modulus.program.projectName, modulus.program.servoNumber], true);
     });
 
   // scale command


### PR DESCRIPTION
Allow use of -s option on command line to allow for auto selection of servo number.

ex : modulus project logs tail -p xxxx -s 2

Signed-off-by: Justin Noel <github@calendee.com>