### PR TITLE
Fix broken link to online CLI docs

### DIFF
--- a/lib/modulus.js
+++ b/lib/modulus.js
@@ -18,7 +18,7 @@ modulus.printHeader = function() {
   modulus.io.print('    \\/_/  \\/_/ \\/_____/ \\/____/  \\/_____/ \\/_____/ \\/_____/ \\/_____/'.verbose);
   modulus.io.print('');
   modulus.io.print('     Providing all the awesomeness that is Modulus, in a CLI.'.verbose);
-  modulus.io.print('     https://modulus.io/codex/cli/using_the_cli'.verbose);
+  modulus.io.print('     http://help.modulus.io/customer/portal/articles/1701977'.verbose);
   modulus.io.print('');
 };
 


### PR DESCRIPTION
The old link had started redirecting to a generic top-level help page. 

This updated link goes to a main page about the CLI.