### PR TITLE
Bump `demeteorizer` to 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "async": "0.1.x",
     "colors": "0.6.x",
     "commander-plus": "0.0.x",
-    "demeteorizer": "2.1.1",
+    "demeteorizer": "2.1.2",
     "find-file-sync": "0.0.2",
     "fs-tools": "~0.2.10",
     "fstream-ignore": "0.0.x",


### PR DESCRIPTION
Includes fixes for `meteor` users that reduces the pollution of the `package.json` generated for them.