### PR TITLE
Adds `--meteor-debug` support.

### DIFF
--- a/lib/controllers/project.js
+++ b/lib/controllers/project.js
@@ -667,11 +667,15 @@ Project.prototype.demeteorize = function(dir, meteorDebug, callback) {
     fsTools.removeSync(out);
   }
 
-  demeteorizer(
-    { input: dir, directory: out, architecture: 'os.linux.x86_64' },
-    function(err) {
-      callback(err, out);
-    });
+  demeteorizer({
+    input: dir,
+    debug: meteorDebug,
+    directory: out,
+    architecture: 'os.linux.x86_64'
+  },
+  function(err) {
+    callback(err, out);
+  });
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Debug support was broken when moving to demeteorizer@3.x.x, this adds
it back.

Closes #56.