### PR TITLE
Enhancement/update dependencies

### DIFF
--- a/lib/modulus.js
+++ b/lib/modulus.js
@@ -27,7 +27,8 @@ var colors     = require('./common/colors');
 var userConfig = require('./common/api').userConfig;
 
 var modulus     = module.exports;
-modulus.version = require('../package').version;
+var pkg = require('../package.json');
+modulus.version = pkg.version;
 
 modulus.program = require('commander-plus');
 modulus.program.Settings.autoHelp = false;
@@ -80,7 +81,7 @@ modulus.runCommand = function (command, args, authRequired) {
   modulus.io.print('Welcome to ' + 'Modulus'.magenta);
 
   var diff = require('update-notifier')({
-    packagePath: path.resolve(__dirname, '..', 'package.json')
+    pkg: pkg
   }).update;
 
   if (diff) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "commander-plus": "0.0.x",
     "find-file-sync": "0.0.2",
     "fs-tools": "~0.2.10",
-    "fstream-ignore": "0.0.x",
+    "fstream-ignore": "^1.0.5",
     "node-uuid": "1.3.3",
     "opener": "~1.3.0",
     "progress": "0.1.x",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "text-table": "0.2.0",
     "through": "2.3.4",
     "underscore": "1.4.x",
-    "update-notifier": "~0.1.7",
+    "update-notifier": "^1.0.2",
     "zip-stream": "0.5.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- bump `fstream-ignore`
- bump `update-notifier`

Removes `node@v6` installation warning
Closes #120 