### PR TITLE
Add ability to get project build logs

### DIFF
--- a/lib/commands/project.js
+++ b/lib/commands/project.js
@@ -700,6 +700,47 @@ project.deploy = function (projectName, dir, includeModules, registry, withTests
 
 //-----------------------------------------------------------------------------
 /**
+ * Description - Get the deploy logs for a specific project.
+ * @param {string} projectName - name of the project to retrieve deploy logs from.
+ * @param {function} cb Callback invoked with deploy log data.
+ */
+//-----------------------------------------------------------------------------
+project.getDeployLogs = function (projectName, cb) {
+  var user = userConfig.data;
+  var message = 'You currently have no projects. You can create one with "project create".';
+
+  async.waterfall([
+    function getProjects(next) {
+      projectController.find({ userId: user.userId }, function (err, projects) {
+        if (err) {
+          err = error.handleApiError(err, 'GET_PROJECT_DEPLOY_LOGS', next);
+          return next(err);
+        }
+
+        if (projects.length === 0) return next(message);
+        next(null, projects);
+      });
+    },
+    function selectProject(projects, next) {
+      project.chooseProjectPrompt(projects, projectName, next);
+    },
+    function handleDeployLogs(project, next) {
+      message = 'You must deploy to your project to view deploy logs';
+      if (project.status === 'NONE') return next(message);
+
+      projectController.getDeployLogs(project.id, function (err, logs) {
+        if (err) return next(err);
+
+        modulus.io.print(logs.build);
+        modulus.io.success('Deploy logs successfully retrieved.');
+        next();
+      });
+    }
+  ], cb);
+};
+
+//-----------------------------------------------------------------------------
+/**
  * Description - Gets the logs for a specific project. May download or print to console.
  * @param {string} projectName - name of the project to retrieve logs from.
  * @param {string} download - flag to swap between printing and downloading logs.

--- a/lib/commands/project.js
+++ b/lib/commands/project.js
@@ -730,6 +730,7 @@ project.getDeployLogs = function (projectName, cb) {
 
       projectController.getDeployLogs(project.id, function (err, logs) {
         if (err) return next(err);
+        if (!logs || !logs.build) return next('Project has no build logs.');
 
         modulus.io.print(logs.build);
         modulus.io.success('Deploy logs successfully retrieved.');

--- a/lib/controllers/project.js
+++ b/lib/controllers/project.js
@@ -403,6 +403,16 @@ Project.prototype._deploy = function(projectId, file, registry, withTests, callb
 };
 
 /**
+ * Gets the deploy logs for the specified project id.
+ * @param {string} projectId The ID of the project.
+ * @param {function} callback Function invoked with log results.
+ */
+//-----------------------------------------------------------------------------
+Project.prototype.getDeployLogs = function(projectId, callback) {
+  librarian.project.getDeployLogs(projectId, userConfig.data.apiKey, callback);
+};
+
+/**
  * Gets the logs for the specified project id.
  * @param {string} projectId The ID of the project.
  * @param {function} callback Function invoked with log results.

--- a/lib/routes/project.js
+++ b/lib/routes/project.js
@@ -209,6 +209,50 @@ module.exports = function (modulus) {
         true);
     });
 
+  function deployLogsHandler() {
+    modulus.runCommand(
+      modulus.commands.project.getDeployLogs,
+      [
+        modulus.program.projectName
+      ],
+      true);
+  }
+
+  // deployLogs command
+  help.add('deployLogs', function () {
+    this.line('project deployLogs'.verbose);
+    this.line('Gets deploy logs for the selected project.'.input);
+    this.line('  options:'.input);
+    this.line('    -p, --project-name   Name of the project to retrieve deploy logs from. Prompts are skipped when specified.'.input);
+    this.line('');
+  });
+
+  modulus.program
+    .command('project deployLogs')
+    .description('Gets logs for the selected project.')
+    .on('--help', function () {
+      help.commands.deployLogs();
+    })
+    .action(deployLogsHandler);
+
+  // project deployLogs -> project deployLog alias
+  modulus.program
+    .command('project deployLog')
+    .description('Gets logs for the selected project.')
+    .on('--help', function () {
+      help.commands.deployLogs();
+    })
+    .action(deployLogsHandler);
+
+  // project logs -> logs alias
+  modulus.program
+    .command('deployLogs')
+    .description('Gets logs for the selected project.')
+    .on('--help', function () {
+      help.commands.deployLogs();
+    })
+    .action(deployLogsHandler);
+
   // logs command
   help.add('logs', function () {
     this.line('project logs'.verbose);


### PR DESCRIPTION
Commands
```bash
$ modulus deployLogs
$ modulus project deployLogs
$ modulus project deployLog (follows convention of modulus project log(s))
```

Closes #74 