### PR TITLE
Do not uplaod .nvmrc with source bundle

### DIFF
--- a/lib/controllers/.modulus-base-ignore
+++ b/lib/controllers/.modulus-base-ignore
@@ -5,3 +5,4 @@
 modulus-auto-zip-*
 __MACOSX/
 .DS_Store
+.nvmrc


### PR DESCRIPTION
Close #145 

Tested with a Meteor deploy that had a `.nvmrc`. The `.nvmrc` file was NOT uploaded with the source bundle. Deploy was successful.